### PR TITLE
fix: url is prefixed with 'undefined'

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = (nextConfig = {}) => {
           {
             loader: 'file-loader',
             options: {
-              publicPath: `${nextConfig.assetPrefix}/_next/static/videos/`,
+              publicPath: `${nextConfig.assetPrefix || ''}/_next/static/videos/`,
               outputPath: `${isServer ? '../' : ''}static/videos/`,
               name: '[name]-[hash].[ext]',
             },


### PR DESCRIPTION
# Why
If `assetPrefix` is not defined in `nextConfig`, the url is prefixed with `undefined`.

# What I did
fallback to empty string in case of `assetPrefix` is not defined.