### PR TITLE
Fix file-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = (nextConfig = {}) => {
         test: /\.(mp4|webm|ogg|swf|ogv)$/,
         use: [
           {
-            loader: 'file-loader',
+            loader: require.resolve('file-loader'),
             options: {
               publicPath: `${nextConfig.assetPrefix || ''}/_next/static/videos/`,
               outputPath: `${isServer ? '../' : ''}static/videos/`,


### PR DESCRIPTION
The file loader is broken on the latest NextJS. It emits ```[object Module]``` instead of the actual path to the video.

**Example**

The following Input

```
<video src={require('../assets/video.mp4')} />
```

resolves to

```
<video src="[object Module]" /> 
```

This PR fixes it.