### PR TITLE
Removes assetDirectory as a config option and uses /static as the asset route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Next Videos
+
 [![npm version](https://badge.fury.io/js/next-videos.svg)](https://badge.fury.io/js/next-videos)
 
 Import videos (mp4, webm, ogg, swf, ogv) in Next.js.
 
 ## Features
 
-* Load videos from local
-* Load videos from remote (CDN for example) with [assetPrefix](https://github.com/zeit/next.js/#dynamic-assetprefix)
-* Adds a content hash to the file name so videos can get cached
+- Load videos from local
+- Load videos from remote (CDN for example) with [assetPrefix](https://github.com/zeit/next.js/#dynamic-assetprefix)
+- Adds a content hash to the file name so videos can get cached
 
 ## Installation
 
@@ -21,7 +22,7 @@ Create a `next.config.js` in your project
 
 ```js
 // next.config.js
-const withVideos = require('next-videos')
+const withVideos = require("next-videos")
 
 module.exports = withVideos()
 ```
@@ -31,7 +32,7 @@ And you just import it in your component using `require()`
 ```js
 export default () => (
   <div>
-    <video src={require('./video.mp4')} />
+    <video src={require("./video.mp4")} />
   </div>
 )
 ```
@@ -39,31 +40,17 @@ export default () => (
 ## Options
 
 ### assetPrefix
+
 You can serve your videos to a remote url by setting `assetPrefix` option
 
 ```js
-const withVideos = require('next-videos')
+const withVideos = require("next-videos")
 
 module.exports = withVideos({
-  assetPrefix: 'https://example.com',
+  assetPrefix: "https://example.com",
 
   webpack(config, options) {
     return config
-  }
+  },
 })
 ```
-
-### assetDirectory
-With [Next.js 9.1](https://nextjs.org/blog/next-9-1#public-directory-support), assets are now served under `public` and not `static` directory. This is an option to manage which path you are using. Default value is now `public`.
-
-```js
-const withVideos = require('next-videos')
-
-module.exports = withVideos({
-  assetDirectory: 'static',
-
-  webpack(config, options) {
-    return config
-  }
-})
-``

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Next Videos
-
 [![npm version](https://badge.fury.io/js/next-videos.svg)](https://badge.fury.io/js/next-videos)
 
 Import videos (mp4, webm, ogg, swf, ogv) in Next.js.
 
 ## Features
 
-- Load videos from local
-- Load videos from remote (CDN for example) with [assetPrefix](https://github.com/zeit/next.js/#dynamic-assetprefix)
-- Adds a content hash to the file name so videos can get cached
+* Load videos from local
+* Load videos from remote (CDN for example) with [assetPrefix](https://github.com/zeit/next.js/#dynamic-assetprefix)
+* Adds a content hash to the file name so videos can get cached
 
 ## Installation
 
@@ -22,7 +21,7 @@ Create a `next.config.js` in your project
 
 ```js
 // next.config.js
-const withVideos = require("next-videos")
+const withVideos = require('next-videos')
 
 module.exports = withVideos()
 ```
@@ -32,7 +31,7 @@ And you just import it in your component using `require()`
 ```js
 export default () => (
   <div>
-    <video src={require("./video.mp4")} />
+    <video src={require('./video.mp4')} />
   </div>
 )
 ```
@@ -40,17 +39,16 @@ export default () => (
 ## Options
 
 ### assetPrefix
-
 You can serve your videos to a remote url by setting `assetPrefix` option
 
 ```js
-const withVideos = require("next-videos")
+const withVideos = require('next-videos')
 
 module.exports = withVideos({
-  assetPrefix: "https://example.com",
+  assetPrefix: 'https://example.com',
 
   webpack(config, options) {
     return config
-  },
+  }
 })
 ```

--- a/index.js
+++ b/index.js
@@ -1,36 +1,35 @@
 module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
-      const { isServer } = options;
+      const { isServer } = options
 
       if (!options.defaultLoaders) {
         throw new Error(
-          'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
+          "This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade"
         )
       }
 
-      const prefix = nextConfig.assetPrefix || '';
-      const directory = nextConfig.assetDirectory || 'public';
+      const prefix = nextConfig.assetPrefix || ""
 
       config.module.rules.push({
         test: /\.(mp4|webm|ogg|swf|ogv)$/,
         use: [
           {
-            loader: require.resolve('file-loader'),
+            loader: require.resolve("file-loader"),
             options: {
-              publicPath: `${prefix}/_next/${directory}/videos/`,
-              outputPath: `${isServer ? '../' : ''}${directory}/videos/`,
-              name: '[name]-[hash].[ext]',
+              publicPath: `${prefix}/_next/static/videos/`,
+              outputPath: `${isServer ? "../" : ""}static/videos/`,
+              name: "[name]-[hash].[ext]",
             },
           },
         ],
-      });
+      })
 
-      if (typeof nextConfig.webpack === 'function') {
-        return nextConfig.webpack(config, options);
+      if (typeof nextConfig.webpack === "function") {
+        return nextConfig.webpack(config, options)
       }
 
-      return config;
+      return config
     },
-  });
-};
+  })
+}

--- a/index.js
+++ b/index.js
@@ -1,35 +1,35 @@
 module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
-      const { isServer } = options
+      const { isServer } = options;
 
       if (!options.defaultLoaders) {
         throw new Error(
-          "This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade"
+          'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
         )
       }
 
-      const prefix = nextConfig.assetPrefix || ""
+      const prefix = nextConfig.assetPrefix || '';
 
       config.module.rules.push({
         test: /\.(mp4|webm|ogg|swf|ogv)$/,
         use: [
           {
-            loader: require.resolve("file-loader"),
+            loader: require.resolve('file-loader'),
             options: {
               publicPath: `${prefix}/_next/static/videos/`,
-              outputPath: `${isServer ? "../" : ""}static/videos/`,
-              name: "[name]-[hash].[ext]",
+              outputPath: `${isServer ? '../' : ''}static/videos/`,
+              name: '[name]-[hash].[ext]',
             },
           },
         ],
-      })
+      });
 
-      if (typeof nextConfig.webpack === "function") {
-        return nextConfig.webpack(config, options)
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options);
       }
 
-      return config
+      return config;
     },
-  })
-}
+  });
+};


### PR DESCRIPTION
Without passing `static` to the `assetDirectory` config option the default `/public` route causes the assets to `404`

![Screen Shot 2020-09-01 at 1 48 02 PM](https://user-images.githubusercontent.com/21182806/91892987-81b00200-ec61-11ea-92cd-e2b485c8182e.png)

Despite the file being loaded correctly:

![Screen Shot 2020-09-01 at 1 47 34 PM](https://user-images.githubusercontent.com/21182806/91893156-b623be00-ec61-11ea-81c2-e15d0fc9964c.png)

Passing `static` as an option to `assetDirectory` fixes this issue: 

![Screen Shot 2020-09-01 at 1 53 11 PM](https://user-images.githubusercontent.com/21182806/91893144-b2903700-ec61-11ea-8fbe-4bec79984a31.png)

This PR removes the `assetDirectory` option altogether, as the docs mention here: https://nextjs.org/blog/next-9-1#public-directory-support, the `/public` directory will serve assets to the root of the project.

> For example, public/robots.txt will be mapped to /robots.txt.

Following this convention the assets shouldn't be prefixed with `/public` but should follow the `/static/videos/video.mp4` routing.

